### PR TITLE
Ability to add tags to docker images.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 ARG repo_ch="deb http://repo.yandex.ru/clickhouse/trusty stable main"
 ARG repo_ch_key="E0C56BD4"
-ARG ch_version=\*
+ARG ch_version=1.5
 
 ARG repo_java="deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main"
 ARG repo_java_src="deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main"


### PR DESCRIPTION
Set installed version of graphouse.

To add tags do docker images you need to set something like this in image build settings on docker hub.

![image](https://user-images.githubusercontent.com/3152421/34320383-43d546a6-e80a-11e7-8652-a2797f02eb09.png)

Then set tag in git repo and dockerhub builds image with this tag.